### PR TITLE
use theme config helper

### DIFF
--- a/config/theme-coreuiv2.php
+++ b/config/theme-coreuiv2.php
@@ -1,5 +1,42 @@
 <?php
 
 return [
-    //
+
+    /*
+    |--------------------------------------------------------------------------
+    | Theme Configuration Values
+    |--------------------------------------------------------------------------
+    |
+    | The file provides extra configs on top of config/backpack/ui.php
+    |
+    | Any value set here will override the ones defined in
+    | config/backpack/ui.php when this theme is in use.
+    |
+    */
+
+    // -------
+    // CLASSES
+    // -------
+
+    // These can help make the admin panel look similar to your project's design.
+    'classes' => [
+
+        'header' => 'app-header bg-light border-0 navbar',
+        // For background colors use: bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan, bg-white
+        // For links to be visible on different background colors use: "navbar-dark", "navbar-light", "navbar-color"
+
+        'body' => 'app aside-menu-fixed sidebar-lg-show',
+        // Try sidebar-hidden, sidebar-fixed, sidebar-compact, sidebar-lg-show
+
+        'sidebar' => 'sidebar sidebar-pills bg-light',
+        // Remove "sidebar-transparent" for standard sidebar look
+        // Try "sidebar-light" or "sidebar-dark" for dark/light links
+        // You can also add a background class like bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan
+
+        'footer' => 'app-footer d-print-none',
+        // hide it with d-none
+        // change background color with bg-dark, bg-primary, bg-secondary, bg-danger, bg-warning, bg-success, bg-info, bg-blue, bg-light-blue, bg-indigo, bg-purple, bg-pink, bg-red, bg-orange, bg-yellow, bg-green, bg-teal, bg-cyan, bg-white
+
+    ]
+
 ];

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,7 +1,7 @@
 @extends(backpack_view('blank'))
 
 @php
-    if (config('backpack.base.show_getting_started')) {
+    if (config_theme_config('show_getting_started')) {
         $widgets['before_content'][] = [
             'type'        => 'view',
             'view'        => 'backpack::inc.getting_started',

--- a/resources/views/inc/breadcrumbs.blade.php
+++ b/resources/views/inc/breadcrumbs.blade.php
@@ -1,6 +1,6 @@
-@if (config('backpack.base.breadcrumbs') && isset($breadcrumbs) && is_array($breadcrumbs) && count($breadcrumbs))
+@if (backpack_theme_config('breadcrumbs') && isset($breadcrumbs) && is_array($breadcrumbs) && count($breadcrumbs))
 	<nav aria-label="breadcrumb" class="d-none d-lg-block">
-	  <ol class="breadcrumb bg-transparent p-0 {{ config('backpack.base.html_direction') == 'rtl' ? 'justify-content-start' : 'justify-content-end' }}">
+	  <ol class="breadcrumb bg-transparent p-0 {{ backpack_theme_config('html_direction') == 'rtl' ? 'justify-content-start' : 'justify-content-end' }}">
 	  	@foreach ($breadcrumbs as $label => $link)
 	  		@if ($link)
 			    <li class="breadcrumb-item text-capitalize"><a href="{{ $link }}">{{ $label }}</a></li>

--- a/resources/views/inc/footer.blade.php
+++ b/resources/views/inc/footer.blade.php
@@ -1,9 +1,9 @@
-@if (config('backpack.base.show_powered_by') || config('backpack.base.developer_link'))
+@if (backpack_theme_config('show_powered_by') || config('developer_link'))
     <div class="text-muted ml-auto mr-auto">
-      @if (config('backpack.base.developer_link') && config('backpack.base.developer_name'))
-      {{ trans('backpack::base.handcrafted_by') }} <a target="_blank" rel="noopener" href="{{ config('backpack.base.developer_link') }}">{{ config('backpack.base.developer_name') }}</a>.
+      @if (backpack_theme_config('developer_link') && backpack_theme_config('developer_name'))
+      {{ trans('backpack::base.handcrafted_by') }} <a target="_blank" rel="noopener" href="{{ backpack_theme_config('developer_link') }}">{{ backpack_theme_config('developer_name') }}</a>.
       @endif
-      @if (config('backpack.base.show_powered_by'))
+      @if (backpack_theme_config('show_powered_by'))
       {{ trans('backpack::base.powered_by') }} <a target="_blank" rel="noopener" href="http://backpackforlaravel.com?ref=panel_footer_link">Backpack for Laravel</a>.
       @endif
     </div>

--- a/resources/views/inc/head.blade.php
+++ b/resources/views/inc/head.blade.php
@@ -1,10 +1,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
-    @if (config('backpack.base.meta_robots_content'))<meta name="robots" content="{{ config('backpack.base.meta_robots_content', 'noindex, nofollow') }}"> @endif
+    @if (backpack_theme_config('meta_robots_content'))<meta name="robots" content="{{ backpack_theme_config('meta_robots_content', 'noindex, nofollow') }}"> @endif
 
     <meta name="csrf-token" content="{{ csrf_token() }}" /> {{-- Encrypted CSRF token for Laravel, in order for Ajax requests to work --}}
-    <title>{{ isset($title) ? $title.' :: '.config('backpack.base.project_name') : config('backpack.base.project_name') }}</title>
+    <title>{{ isset($title) ? $title.' :: '.backpack_theme_config('project_name') : backpack_theme_config('project_name') }}</title>
 
     @yield('before_styles')
     @stack('before_styles')
@@ -16,8 +16,8 @@
         @basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-solid-900.woff2')
         @basset('https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/fonts/la-brands-400.woff2')
 
-    @if (config('backpack.base.styles') && count(config('backpack.base.styles')))
-        @foreach (config('backpack.base.styles') as $path)
+    @if (backpack_theme_config('styles') && count(backpack_theme_config('styles')))
+        @foreach (backpack_theme_config('styles') as $path)
             @if(is_array($path))
                 @basset(...$path)
             @else
@@ -26,14 +26,14 @@
         @endforeach
     @endif
 
-    @if (config('backpack.base.mix_styles') && count(config('backpack.base.mix_styles')))
-        @foreach (config('backpack.base.mix_styles') as $path => $manifest)
+    @if (backpack_theme_config('mix_styles') && count(backpack_theme_config('mix_styles')))
+        @foreach (backpack_theme_config('mix_styles') as $path => $manifest)
         <link rel="stylesheet" type="text/css" href="{{ mix($path, $manifest) }}">
         @endforeach
     @endif
 
-    @if (config('backpack.base.vite_styles') && count(config('backpack.base.vite_styles')))
-        @vite(config('backpack.base.vite_styles'))
+    @if (backpack_theme_config('vite_styles') && count(backpack_theme_config('vite_styles')))
+        @vite(backpack_theme_config('vite_styles'))
     @endif
 
     @yield('after_styles')

--- a/resources/views/inc/main_header.blade.php
+++ b/resources/views/inc/main_header.blade.php
@@ -1,10 +1,10 @@
-<header class="{{ config('backpack.base.header_class') }}">
+<header class="{{ backpack_theme_config('classes.header') }}">
   {{-- Logo --}}
   <button class="navbar-toggler sidebar-toggler d-lg-none mr-auto ml-3" type="button" data-toggle="sidebar-show" aria-label="{{ trans('backpack::base.toggle_navigation')}}">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <a class="navbar-brand" href="{{ url(config('backpack.base.home_link')) }}" title="{{ config('backpack.base.project_name') }}">
-    {!! config('backpack.base.project_logo') !!}
+  <a class="navbar-brand" href="{{ url(backpack_theme_config('home_link')) }}" title="{{ backpack_theme_config('project_name') }}">
+    {!! backpack_theme_config('project_logo') !!}
   </a>
   <button class="navbar-toggler sidebar-toggler d-md-down-none" type="button" data-toggle="sidebar-lg-show" aria-label="{{ trans('backpack::base.toggle_navigation')}}">
     <span class="navbar-toggler-icon"></span>

--- a/resources/views/inc/menu.blade.php
+++ b/resources/views/inc/menu.blade.php
@@ -16,7 +16,7 @@
 {{-- ========================================================= --}}
 {{-- ========= Top menu right items (ordered right) ========== --}}
 {{-- ========================================================= --}}
-<ul class="nav navbar-nav ml-auto @if(config('backpack.base.html_direction') == 'rtl') mr-0 @endif">
+<ul class="nav navbar-nav ml-auto @if(backpack_theme_config('html_direction') == 'rtl') mr-0 @endif">
     @if (backpack_auth()->guest())
         <li class="nav-item"><a class="nav-link" href="{{ route('backpack.auth.login') }}">{{ trans('backpack::base.login') }}</a>
         </li>

--- a/resources/views/inc/menu_user_dropdown.blade.php
+++ b/resources/views/inc/menu_user_dropdown.blade.php
@@ -5,7 +5,7 @@
       {{backpack_user()->getAttribute('name') ? mb_substr(backpack_user()->name, 0, 1, 'UTF-8') : 'A'}}
     </span>
   </a>
-  <div class="dropdown-menu {{ config('backpack.base.html_direction') == 'rtl' ? 'dropdown-menu-left' : 'dropdown-menu-right' }} mr-4 pb-1 pt-1">
+  <div class="dropdown-menu {{ backpack_theme_config('html_direction') == 'rtl' ? 'dropdown-menu-left' : 'dropdown-menu-right' }} mr-4 pb-1 pt-1">
     <a class="dropdown-item" href="{{ route('backpack.account.info') }}"><i class="la la-user"></i> {{ trans('backpack::base.my_account') }}</a>
     <div class="dropdown-divider"></div>
     <a class="dropdown-item" href="{{ backpack_url('logout') }}"><i class="la la-lock"></i> {{ trans('backpack::base.logout') }}</a>

--- a/resources/views/inc/scripts.blade.php
+++ b/resources/views/inc/scripts.blade.php
@@ -6,8 +6,8 @@
 
 @include(backpack_view('inc.theme_scripts'))
 
-@if (config('backpack.base.scripts') && count(config('backpack.base.scripts')))
-    @foreach (config('backpack.base.scripts') as $path)
+@if (backpack_theme_config('scripts') && count(backpack_theme_config('scripts')))
+    @foreach (backpack_theme_config('scripts') as $path)
         @if(is_array($path))
             @basset(...$path)
         @else
@@ -16,14 +16,14 @@
     @endforeach
 @endif
 
-@if (config('backpack.base.mix_scripts') && count(config('backpack.base.mix_scripts')))
-    @foreach (config('backpack.base.mix_scripts') as $path => $manifest)
+@if (backpack_theme_config('mix_scripts') && count(backpack_theme_config('mix_scripts')))
+    @foreach (backpack_theme_config('mix_scripts') as $path => $manifest)
     <script type="text/javascript" src="{{ mix($path, $manifest) }}"></script>
     @endforeach
 @endif
 
-@if (config('backpack.base.vite_scripts') && count(config('backpack.base.vite_scripts')))
-    @vite(config('backpack.base.vite_scripts'))
+@if (backpack_theme_config('vite_scripts') && count(backpack_theme_config('vite_scripts')))
+    @vite(backpack_theme_config('vite_scripts'))
 @endif
 
 @include(backpack_view('inc.alerts'))

--- a/resources/views/inc/sidebar.blade.php
+++ b/resources/views/inc/sidebar.blade.php
@@ -1,6 +1,6 @@
 @if (backpack_auth()->check())
     {{-- Left side column. contains the sidebar --}}
-    <div class="{{ config('backpack.base.sidebar_class') }}">
+    <div class="{{ backpack_theme_config('classes.sidebar') }}">
       {{-- sidebar: style can be found in sidebar.less --}}
       <nav class="sidebar-nav overflow-hidden">
         {{-- sidebar menu: : style can be found in sidebar.less --}}

--- a/resources/views/layouts/plain.blade.php
+++ b/resources/views/layouts/plain.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ app()->getLocale() }}" dir="{{ config('backpack.base.html_direction') }}">
+<html lang="{{ app()->getLocale() }}" dir="{{ backpack_theme_config('html_direction') }}">
 <head>
     @include(backpack_view('inc.head'))
 </head>

--- a/resources/views/layouts/top_left.blade.php
+++ b/resources/views/layouts/top_left.blade.php
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 
-<html lang="{{ app()->getLocale() }}" dir="{{ config('backpack.base.html_direction') }}">
+<html lang="{{ app()->getLocale() }}" dir="{{ backpack_theme_config('html_direction') }}">
 
 <head>
   @include(backpack_view('inc.head'))
 
 </head>
 
-<body class="{{ config('backpack.base.body_class') }}">
+<body class="{{ backpack_theme_config('classes.body') }}">
 
   @include(backpack_view('inc.main_header'))
 
@@ -39,7 +39,7 @@
 
   </div>{{-- ./app-body --}}
 
-  <footer class="{{ config('backpack.base.footer_class') }}">
+  <footer class="{{ backpack_theme_config('classes.footer') }}">
     @include(backpack_view('inc.footer'))
   </footer>
 


### PR DESCRIPTION
## Change 1

Before, classes were level-1 configs (`header_class`)... now they are level-2 configs (`classes.header`).

## Change 2

Before, classes were defined in the `config/backpack/base.php` file, now the are defined in the theme config file, where they make more sense.

## Change 3

Before, we were using `config('backpack.base.breadcrumbs')` so there was no way for this theme to override that.

Now, we are using `backpack_theme_config('breadcrumbs')` which picks up the value for this theme's config file, if it exists. Otherwise it falls back to the value set in `config/backpack/ui.php`
