### PR TITLE
style page-heading sections

### DIFF
--- a/resources/assets/css/coreuiv2.css
+++ b/resources/assets/css/coreuiv2.css
@@ -8,3 +8,8 @@
 #crudTable {
     background-color: #FFFFFF !important;
 }
+
+h1[bp-section=page-heading] {
+    font-size: 2rem;
+    line-height: 2.1rem;
+}


### PR DESCRIPTION
In https://github.com/Laravel-Backpack/CRUD/pull/4931 we made all page headings `h1` instead of all across the board. And added an easy way to select it for styling. So let's do that - let's style the page-heading `h1` for all Backpack pages, in one place, for this theme.