### PR TITLE
add popper js

### DIFF
--- a/resources/views/inc/theme_scripts.blade.php
+++ b/resources/views/inc/theme_scripts.blade.php
@@ -1,2 +1,3 @@
+@basset("https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js")
 @basset('https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/js/bootstrap.min.js')
 @basset('https://unpkg.com/@coreui/coreui@2.1.16/dist/js/coreui.js')


### PR DESCRIPTION
Don't ask me why, don't ask me when. 

Popper.js was added as a CRUD dependency, the problem is that the version added only supports BS5. 

Apparently including two versions has no issues (maybe because of loading order, or whatever reason I don't know), so here we are, including a version that works with BS4. 

Everything seems to work so I assume I got lucky. 

