### PR TITLE
Conditinally display links

### DIFF
--- a/resources/views/inc/menu_user_dropdown.blade.php
+++ b/resources/views/inc/menu_user_dropdown.blade.php
@@ -6,8 +6,10 @@
     </span>
   </a>
   <div class="dropdown-menu {{ backpack_theme_config('html_direction') == 'rtl' ? 'dropdown-menu-left' : 'dropdown-menu-right' }} mr-4 pb-1 pt-1">
-    <a class="dropdown-item" href="{{ route('backpack.account.info') }}"><i class="la la-user"></i> {{ trans('backpack::base.my_account') }}</a>
-    <div class="dropdown-divider"></div>
+    @if(config('backpack.base.setup_my_account_routes'))
+      <a class="dropdown-item" href="{{ route('backpack.account.info') }}"><i class="la la-user"></i> {{ trans('backpack::base.my_account') }}</a>
+      <div class="dropdown-divider"></div>
+    @endif
     <a class="dropdown-item" href="{{ backpack_url('logout') }}"><i class="la la-lock"></i> {{ trans('backpack::base.logout') }}</a>
   </div>
 </li>


### PR DESCRIPTION
reported in https://github.com/Laravel-Backpack/CRUD/issues/5188

Some routes may not be available if you disable certain options in config like `setup_my_account_routes` and `setup_password_recovery_routes`.

If not checked the would throw errors that the route is not defined.

