### PR TITLE
[Bug Fix] Sidebar dropdown does not open when clicking on the title.

### DIFF
--- a/resources/assets/css/coreuiv2.css
+++ b/resources/assets/css/coreuiv2.css
@@ -26,6 +26,10 @@ h1[bp-section=page-heading] {
     left: -16px !important;
 }
 
+.sidebar.sidebar-pills .nav-link > span {
+    pointer-events: none;
+}
+
 .sidebar.sidebar-pills .nav-dropdown .nav-link:not(.nav-dropdown-toggle),
 .sidebar.sidebar-pills .nav-dropdown .nav-title {
     padding-left: 1.5rem;


### PR DESCRIPTION
Fix for https://github.com/Laravel-Backpack/theme-coreuiv2/issues/24

I couldn't find the root cause of the issue, so this is a tape over it 😶
Pointer events are disabled for the text, allowing clicks to go through to the correct element 👌