### PR TITLE
Check if the nav-link has href before calling function on it

### DIFF
--- a/resources/views/inc/sidebar.blade.php
+++ b/resources/views/inc/sidebar.blade.php
@@ -71,7 +71,7 @@
       // If not found, look for the link that starts with the url
       if(!$curentPageLink.length > 0){
           $curentPageLink = $navLinks.filter( function() {
-            if ($(this).attr('href').startsWith(full_url)) {
+            if ($(this).attr('href')?.startsWith(full_url)) {
               return true;
             }
 


### PR DESCRIPTION
This was "introduced/highlighted" by the language-picker package.

Previously we assumed that all the `nav-links` would have an href that we could compare with `.startsWith`. 

Now the language picker (and in reality any custom code that developers could add to their top bar navigation) highlighted this problem that not all the nav-links need the href, they could be just the placeholders in the dropdown. 

