### PR TITLE
Fix Developer Link Only In The Footer

### DIFF
--- a/resources/views/inc/footer.blade.php
+++ b/resources/views/inc/footer.blade.php
@@ -1,4 +1,4 @@
-@if (backpack_theme_config('show_powered_by') || config('developer_link'))
+@if (backpack_theme_config('show_powered_by') || backpack_theme_config('developer_link'))
     <div class="text-muted ml-auto mr-auto">
       @if (backpack_theme_config('developer_link') && backpack_theme_config('developer_name'))
       {{ trans('backpack::base.handcrafted_by') }} <a target="_blank" rel="noopener" href="{{ backpack_theme_config('developer_link') }}">{{ backpack_theme_config('developer_name') }}</a>.


### PR DESCRIPTION
Greetings,
it appears that a bug has been introduced with this commit: https://github.com/Laravel-Backpack/theme-coreuiv2/commit/e582bf55c8ceb2a0bbb4fbff7c7198378f67fdc1#diff-bc1c12ab7e08a2b625d235d8eb97ca13f08d2e277abe7c4f37239b6c980a75fcR1
The second condition was replaced by `config('developer_link')` but it should have been replaced by `backpack_theme_config('developer_link')`.

This has the effect that it's not possible to show only the `Handcrafted by X` in the footer using the UI config. `show_powered_by` has to be enabled too to show it, which will also show the `Powered by Backpack for Laravel`.