### PR TITLE
load font using relative paths

### DIFF
--- a/resources/assets/css/source-sans-pro.css
+++ b/resources/assets/css/source-sans-pro.css
@@ -3,7 +3,7 @@
     font-weight: 200;
     font-style: normal;
     font-stretch: normal;
-    src: url('/storage/basset/source-sans-pro/SourceSans3-ExtraLight.ttf.woff2') format('woff2');
+    src: url('./../../../../../../source-sans-pro/SourceSans3-ExtraLight.ttf.woff2') format('woff2');
 }
 
 @font-face{
@@ -11,7 +11,7 @@
     font-weight: 200;
     font-style: italic;
     font-stretch: normal;
-    src: url('/storage/basset/source-sans-pro/SourceSans3-ExtraLightIt.ttf.woff2') format('woff2');
+    src: url('./../../../../../../source-sans-pro/SourceSans3-ExtraLightIt.ttf.woff2') format('woff2')
 }
 
 @font-face{
@@ -19,7 +19,7 @@
     font-weight: 300;
     font-style: normal;
     font-stretch: normal;
-    src: url('/storage/basset/source-sans-pro/SourceSans3-Light.ttf.woff2') format('woff2');
+    src: url('./../../../../../../source-sans-pro/SourceSans3-Light.ttf.woff2') format('woff2')
 }
 
 @font-face{
@@ -27,7 +27,7 @@
     font-weight: 300;
     font-style: italic;
     font-stretch: normal;
-    src: url('/storage/basset/source-sans-pro/SourceSans3-LightIt.ttf.woff2') format('woff2');
+    src: url('./../../../../../../source-sans-pro/SourceSans3-LightIt.ttf.woff2') format('woff2')
 }
 
 @font-face{
@@ -35,7 +35,7 @@
     font-weight: 400;
     font-style: normal;
     font-stretch: normal;
-    src: url('/storage/basset/source-sans-pro/SourceSans3-Regular.ttf.woff2') format('woff2');
+    src: url('./../../../../../../source-sans-pro/SourceSans3-Regular.ttf.woff2') format('woff2')
 }
 
 @font-face{
@@ -43,7 +43,8 @@
     font-weight: 400;
     font-style: italic;
     font-stretch: normal;
-    src: url('/storage/basset/source-sans-pro/SourceSans3-It.ttf.woff2') format('woff2');
+    src: url('./../../../../../../source-sans-pro/SourceSans3-It.ttf.woff2') format('woff2')
+
 }
 
 @font-face{
@@ -51,7 +52,7 @@
     font-weight: 600;
     font-style: normal;
     font-stretch: normal;
-    src: url('/storage/basset/source-sans-pro/SourceSans3-Semibold.ttf.woff2') format('woff2');
+    src: url('./../../../../../../source-sans-pro/SourceSans3-Semibold.ttf.woff2') format('woff2')
 }
 
 @font-face{
@@ -59,7 +60,7 @@
     font-weight: 600;
     font-style: italic;
     font-stretch: normal;
-    src: url('/storage/basset/source-sans-pro/SourceSans3-SemiboldIt.ttf.woff2') format('woff2');
+    src: url('./../../../../../../source-sans-pro/SourceSans3-SemiboldIt.ttf.woff2') format('woff2')
 }
 
 @font-face{
@@ -67,7 +68,7 @@
     font-weight: 700;
     font-style: normal;
     font-stretch: normal;
-    src: url('/storage/basset/source-sans-pro/SourceSans3-Bold.ttf.woff2') format('woff2');
+    src: url('./../../../../../../source-sans-pro/SourceSans3-Bold.ttf.woff2') format('woff2');
 }
 
 @font-face{
@@ -75,7 +76,7 @@
     font-weight: 700;
     font-style: italic;
     font-stretch: normal;
-    src: url('/storage/basset/source-sans-pro/SourceSans3-BoldIt.ttf.woff2') format('woff2');
+    src: url('./../../../../../../source-sans-pro/SourceSans3-BoldIt.ttf.woff2') format('woff2');
 }
 
 @font-face{
@@ -83,7 +84,7 @@
     font-weight: 900;
     font-style: normal;
     font-stretch: normal;
-    src: url('/storage/basset/source-sans-pro/SourceSans3-Black.ttf.woff2') format('woff2');
+    src: url('./../../../../../../source-sans-pro/SourceSans3-Black.ttf.woff2') format('woff2');
 }
 
 @font-face{
@@ -91,5 +92,5 @@
     font-weight: 900;
     font-style: italic;
     font-stretch: normal;
-    src: url('/storage/basset/source-sans-pro/SourceSans3-BlackIt.ttf.woff2') format('woff2');
+    src: url('./../../../../../../source-sans-pro/SourceSans3-BlackIt.ttf.woff2') format('woff2');
 }

--- a/resources/views/inc/theme_styles.blade.php
+++ b/resources/views/inc/theme_styles.blade.php
@@ -1,8 +1,10 @@
-@basset('https://unpkg.com/@digitallyhappy/backstrap@0.5.1/dist/css/legacy.css')
 @basset('https://cdnjs.cloudflare.com/ajax/libs/noty/3.1.4/noty.min.css')
+@basset('https://unpkg.com/@digitallyhappy/backstrap@0.5.1/dist/css/legacy.css')
 
-{{-- Source Sans Font --}}
+{{-- Source Sans Font | this definition shouldn't change as the inclusion of the font in css depends on relative file paths --}}
 @bassetArchive(base_path('vendor/backpack/theme-coreuiv2/resources/assets/fonts/source-sans-3.052R.tar.gz'), 'source-sans-pro')
+
+{{-- This file path shouldn't change as the inclusion of the font in css depend on this file relative path --}}
 @basset(base_path('vendor/backpack/theme-coreuiv2/resources/assets/css/source-sans-pro.css'))
 
 {{-- Custom Backpack Rules --}}


### PR DESCRIPTION
This was reported in https://github.com/Laravel-Backpack/community-forum/discussions/1050

`storage/basset` was hardcoded in the font files, so changing any configuration in the default disk would break the font loading. 

font files now load using relative paths, so I also added a note on the relevant files so that we don't forget to keep their paths unchanged, or change all the relevant parts if needed. 