### PR TITLE
fix alerts script

### DIFF
--- a/resources/views/inc/alerts.blade.php
+++ b/resources/views/inc/alerts.blade.php
@@ -12,7 +12,7 @@
             });
 
             // get alerts from the alert bag
-            var $alerts_from_php = {{ Illuminate\Support\Js::from(\Alert::getMessages()) }};
+            var $alerts_from_php = JSON.parse('@json(\Alert::getMessages())');
 
             // get the alerts from the localstorage
             var $alerts_from_localstorage = JSON.parse(localStorage.getItem('backpack_alerts')) ?


### PR DESCRIPTION
related to https://github.com/Laravel-Backpack/CRUD/issues/5695

There was an issue with the alerts script throwing an error when there was no alerts. 

This was missed by us because demo has it fixed 🤷 

Just applied the same fix we have in demo. 