### PR TITLE
downgrade popper.js - fix dropdowns

### DIFF
--- a/resources/views/inc/theme_scripts.blade.php
+++ b/resources/views/inc/theme_scripts.blade.php
@@ -1,3 +1,3 @@
-@basset('https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js', true, ['integrity' => 'sha256-BRqBN7dYgABqtY9Hd4ynE+1slnEw+roEPFzQ7TRRfcg=', 'crossorigin' => 'anonymous'])
+@basset('https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js', true, ['integrity' => 'sha256-/ijcOLwFf26xEYAjW75FizKVo5tnTYiQddPZoLUHHZ8=', 'crossorigin' => 'anonymous'])
 @basset('https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/js/bootstrap.min.js', true, ['integrity' => 'sha512-7rusk8kGPFynZWu26OKbTeI+QPoYchtxsmPeBqkHIEXJxeun4yJ4ISYe7C6sz9wdxeE1Gk3VxsIWgCZTc+vX3g==', 'crossorigin' => 'anonymous'])
 @basset('https://cdn.jsdelivr.net/npm/@coreui/coreui@2.1.16/dist/js/coreui.min.js', true, ['integrity' => 'sha256-IEYW8sRtA+cOsgiyWfLZnsSXxew/8p4sqHogSZJ+bcQ=', 'crossorigin' => 'anonymous'])


### PR DESCRIPTION
We updated popper.js to version 2. That was a mistake as that version is not compatible with bootstrap 4. 

I've downgraded to popper.js 1.x and now dropdowns work normally again. 